### PR TITLE
added mask erosion

### DIFF
--- a/src/tapenade/preprocessing/_preprocessing.py
+++ b/src/tapenade/preprocessing/_preprocessing.py
@@ -482,6 +482,7 @@ def compute_mask(
     post_processing_method: str = "fill_holes",
     keep_largest_cc: bool = True,
     registered_image: bool = False,
+    n_erosion_steps: int = 0,
     n_jobs: int = -1,
 ) -> np.ndarray:
     """
@@ -494,11 +495,11 @@ def compute_mask(
     - sigma_blur: float, standard deviation of the Gaussian blur. Should typically be
       around 1/3 of the typical object diameter.
     - threshold_factor: float, factor to multiply the threshold (default: 1)
-    - post_processing_method: str, method to use for post-processing the mask. Can be 'convex_hull' to compute
-      the convex hull of the mask, 'fill_holes' to fill holes in the mask, or 'none' to skip post-processing
-      (default: 'fill_holes')
+    - post_processing_method: str, Can be 'convex_hull' to compute the convex hull of the mask,
+      'fill_holes' to fill holes each plane separately, or 'none' to skip post-processing (default: 'fill_holes')
     - keep_largest_cc: bool, set to True to keep only the largest connected component in the mask (default: True)
     - n_jobs: int, number of parallel jobs to run (-1 for using all available CPUs)
+    - n_erosion_steps: int, number of erosion steps to apply to the mask after post-processing.
 
     Returns:
     - mask: numpy array, binary mask of the same shape as the input image
@@ -515,6 +516,7 @@ def compute_mask(
             post_processing_method=post_processing_method,
             keep_largest_cc=keep_largest_cc,
             registered_image=registered_image,
+            n_erosion_steps=n_erosion_steps,
         )
 
         if n_jobs == 1:
@@ -547,6 +549,7 @@ def compute_mask(
             post_processing_method=post_processing_method,
             keep_largest_cc=keep_largest_cc,
             registered_image=registered_image,
+            n_erosion_steps=n_erosion_steps,
         )
 
     return np.array(mask)

--- a/src/tapenade/preprocessing/_thresholding.py
+++ b/src/tapenade/preprocessing/_thresholding.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.ndimage import gaussian_filter
+from scipy.ndimage import gaussian_filter, binary_erosion
 from scipy.ndimage.morphology import binary_fill_holes
 from skimage.filters import threshold_otsu
 from skimage.measure import label
@@ -222,6 +222,7 @@ def _compute_mask(
     keep_largest_cc: bool = True,
     post_processing_method: str = "fill_holes",
     registered_image: bool = False,
+    n_erosion_steps: int = 0,
 ) -> np.ndarray:
     """
     Process the mask for the given image.
@@ -238,6 +239,7 @@ def _compute_mask(
       the convex hull of the mask, 'fill_holes' to fill holes in each 2D slice of the mask, or 'none' to skip
     - registered_image: bool, set to True if the image has been registered beforehand and thus
       contains large regions of zeros that lead to sharp intensity gradients at the boundaries.
+    - n_erosion_steps: int, number of erosion steps to apply to the mask after post-processing.
 
     Returns:
     - mask: numpy array, binary mask of the same shape as the input image
@@ -263,5 +265,8 @@ def _compute_mask(
     # Refine the mask by keeping only the largest connected component and filling holes
     if keep_largest_cc or post_processing_method != "none":
         mask = _refine_raw_mask(mask, post_processing_method, keep_largest_cc)
+
+    if n_erosion_steps > 0:
+        mask = binary_erosion(mask, iterations=n_erosion_steps, border_value=1)
 
     return mask


### PR DESCRIPTION
Implemented option erode sample masks after computation to prevent "sloppy" borders